### PR TITLE
Add GHC bindist subdir to `meta.json`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687011986,
-        "narHash": "sha256-ZNSi/wBw12d7LO8YcZ4aehIlPp4lgSkKbrHaoF80IKI=",
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c09e8eb8717e240ef9c5727c1cc9186db9fb309",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
         "type": "github"
       },
       "original": {

--- a/ghc-wasm-bindists.cabal
+++ b/ghc-wasm-bindists.cabal
@@ -12,15 +12,18 @@ executable ghc-wasm-bindists
     , conduit
     , containers
     , cryptohash-sha256
+    , deriving-aeson
     , filepath
     , http-conduit
     , lens
     , lens-aeson
+    , lzma-conduit
     , optparse-generic
     , relude
+    , tar-conduit
     , unliftio
   mixins: base hiding (Prelude), relude (Relude as Prelude), relude
   hs-source-dirs: app
   default-language: GHC2021
-  default-extensions: BlockArguments DataKinds DeriveAnyClass DeriveGeneric DerivingStrategies DuplicateRecordFields LambdaCase NoFieldSelectors OverloadedLabels OverloadedRecordDot OverloadedStrings RecordWildCards StrictData
+  default-extensions: ApplicativeDo BlockArguments DataKinds DeriveAnyClass DeriveGeneric DerivingStrategies DerivingVia DuplicateRecordFields LambdaCase NoFieldSelectors OverloadedLabels OverloadedRecordDot OverloadedStrings RecordWildCards StrictData
   ghc-options: -Wall -Werror -Wunused-packages -Wwarn=unused-packages -Wno-name-shadowing


### PR DESCRIPTION
Closes #5

For any GHC bindist that is added/updated in `meta.json` in the future, the GHC bindist subdir will be recorded like this:
```json
    "wasm32-wasi-ghc-gmp": {
        "ghcSubdir": "ghc-9.9.20240105-wasm32-wasi",
        "mirrorUrl": "https://example.org/dl/wasm32-wasi-ghc-gmp.tar.xz",
        "originalUrl": "https://gitlab.haskell.org/api/v4/projects/1/jobs/1745817/artifacts/ghc-x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
        "sriHash": "sha256-55sNGGzVxSHsGoCLLNVmZeCzKp8o78SXOyIFVI0QNF4="
    },
```