### PR TITLE
Another bunch of adjustments

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -125,13 +125,6 @@ data BindistSrc
         artifactPath :: Text,
         pipelineFilter :: [(ByteString, Maybe ByteString)]
       }
-  | GitHubArtifact
-      { ownerRepo :: Text,
-        branch :: Text,
-        workflowName :: Text,
-        artifactName :: Text,
-        event :: Text
-      }
   deriving stock (Show)
 
 getLatestBindistURL :: HTTP.Manager -> BindistSrc -> IO Url
@@ -158,20 +151,6 @@ getLatestBindistURL mgr = \case
 
       downloadUrlForJobId jobId =
         projectUrl <> "/jobs/" <> show jobId <> "/artifacts/" <> artifactPath
-  GitHubArtifact {..} -> do
-    let runsUrl = toString $ "https://api.github.com/repos/" <> ownerRepo <> "/actions" <> "/runs"
-
-    apiRes <- fetch runsUrl [("branch", qv branch), ("event", qv event)]
-    let hasWorkflowName = filteredBy $ key "name" . _String . only workflowName
-    Just runId <-
-      pure $ apiRes ^? key "workflow_runs" . values . hasWorkflowName . key "id" . _Integer
-
-    apiRes <- fetch (runsUrl <> "/" <> show runId <> "/artifacts") []
-    let hasArtifactName = filteredBy $ key "name" . _String . only artifactName
-    Just artifactId <-
-      pure $ apiRes ^? key "artifacts" . values . hasArtifactName . key "id" . _Integer
-
-    pure $ "https://nightly.link/" <> ownerRepo <> "/actions/artifacts/" <> show artifactId <> ".zip"
   where
     fetch url qs = do
       req <- HTTP.setQueryString qs <$> HTTP.parseUrlThrow url
@@ -308,19 +287,6 @@ bindistInfos =
                   jobName = "x86_64-linux",
                   artifactPath = "",
                   pipelineFilter = []
-                }
-          },
-      (,)
-        "binaryen"
-        BindistInfo
-          { isGhcBindist = False,
-            src =
-              GitHubArtifact
-                { ownerRepo = "type-dance/binaryen",
-                  branch = "main",
-                  workflowName = "release",
-                  artifactName = "release-ubuntu-latest",
-                  event = "push"
                 }
           },
       (,)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -193,9 +193,9 @@ bindistInfos =
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1,
                   ref = "master",
-                  jobName = "nightly-x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static",
-                  artifactPath = "ghc-x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
-                  pipelineFilter = [("source", Just "schedule"), ("scope", Just "finished")]
+                  jobName = "nightly-x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static",
+                  artifactPath = "ghc-x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
+                  pipelineFilter = [("source", Just "schedule")]
                 }
           },
       (,)
@@ -207,9 +207,9 @@ bindistInfos =
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1,
                   ref = "master",
-                  jobName = "nightly-x86_64-linux-alpine3_17-wasm-int_native-cross_wasm32-wasi-release+fully_static",
-                  artifactPath = "ghc-x86_64-linux-alpine3_17-wasm-int_native-cross_wasm32-wasi-release+fully_static.tar.xz",
-                  pipelineFilter = [("source", Just "schedule"), ("scope", Just "finished")]
+                  jobName = "nightly-x86_64-linux-alpine3_18-wasm-int_native-cross_wasm32-wasi-release+fully_static",
+                  artifactPath = "ghc-x86_64-linux-alpine3_18-wasm-int_native-cross_wasm32-wasi-release+fully_static.tar.xz",
+                  pipelineFilter = [("source", Just "schedule")]
                 }
           },
       (,)
@@ -221,9 +221,9 @@ bindistInfos =
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1,
                   ref = "master",
-                  jobName = "nightly-x86_64-linux-alpine3_17-wasm-unreg-cross_wasm32-wasi-release+fully_static",
-                  artifactPath = "ghc-x86_64-linux-alpine3_17-wasm-unreg-cross_wasm32-wasi-release+fully_static.tar.xz",
-                  pipelineFilter = [("source", Just "schedule"), ("scope", Just "finished")]
+                  jobName = "nightly-x86_64-linux-alpine3_18-wasm-unreg-cross_wasm32-wasi-release+fully_static",
+                  artifactPath = "ghc-x86_64-linux-alpine3_18-wasm-unreg-cross_wasm32-wasi-release+fully_static.tar.xz",
+                  pipelineFilter = [("source", Just "schedule")]
                 }
           },
       (,)
@@ -235,8 +235,8 @@ bindistInfos =
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 3223,
                   ref = "ghc-9.6",
-                  jobName = "x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static",
-                  artifactPath = "ghc-x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
+                  jobName = "x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static",
+                  artifactPath = "ghc-x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
                   pipelineFilter = []
                 }
           },
@@ -249,8 +249,8 @@ bindistInfos =
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 3223,
                   ref = "ghc-9.8",
-                  jobName = "x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static",
-                  artifactPath = "ghc-x86_64-linux-alpine3_17-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
+                  jobName = "x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static",
+                  artifactPath = "ghc-x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
                   pipelineFilter = []
                 }
           },


### PR DESCRIPTION
- GHC wasm bindists are now produced using alpine3_18 CI images
- Remove scope=finished pipeline filters, upstream nightly pipelines can be ridiculously long sometimes
- Remove binaryen mirroring logic as well as unused GitHubArtifact functionality