### PR TITLE
Add GHC 9.10 artifact

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -234,6 +234,20 @@ bindistInfos =
                 }
           },
       (,)
+        "wasm32-wasi-ghc-9.10"
+        BindistInfo
+          { isGhcBindist = True,
+            src =
+              GitLabArtifact
+                { gitlabDomain = "gitlab.haskell.org",
+                  projectId = 1,
+                  ref = "ghc-9.10",
+                  jobName = "x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static",
+                  artifactPath = "ghc-x86_64-linux-alpine3_18-wasm-cross_wasm32-wasi-release+fully_static.tar.xz",
+                  pipelineFilter = [] -- [("status", Just "success")]
+                }
+          },
+      (,)
         "wasi-sdk"
         BindistInfo
           { isGhcBindist = False,


### PR DESCRIPTION
```haskell
pipelineFilter = [("status", Just "success")]
```
does not yet work (there are failures in other jobs, see eg [here](https://gitlab.haskell.org/ghc/ghc/-/pipelines/91551)), maybe we want to defer merging this?