### PR TITLE
Add aarch64-linux bindist CI job and mirroring logic

### DIFF
--- a/.github/workflows/aarch64-linux-bindist.yml
+++ b/.github/workflows/aarch64-linux-bindist.yml
@@ -1,0 +1,69 @@
+name: ghc-wasm-aarch64-linux-bindist
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/aarch64-linux-bindist.yml
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0'
+
+jobs:
+  ghc-wasm-aarch64-linux-bindist:
+    name: ghc-wasm-aarch64-linux-bindist
+    runs-on: makima
+    steps:
+
+      - name: update-system-deps
+        run: |
+          sudo dnf upgrade -y
+
+      - name: setup-haskell
+        uses: haskell-actions/setup@v2
+
+      - name: setup-cabal-deps
+        run: |
+          cabal install \
+            --overwrite-policy=always \
+            alex \
+            happy
+
+      - name: setup-ghc-wasm-meta
+        run: |
+          curl https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=${{ runner.temp }}/.ghc-wasm SKIP_GHC=1 sh
+          ${{ runner.temp }}/.ghc-wasm/add_to_github_path.sh
+
+      - name: build-hadrian
+        working-directory: ${{ runner.temp }}
+        run: |
+          git clone --depth=1 --recurse-submodules --shallow-submodules --jobs 32 https://gitlab.haskell.org/ghc/ghc.git
+          cd ghc
+          ./hadrian/build --version
+
+      - name: configure-ghc
+        working-directory: ${{ runner.temp }}/ghc
+        run: |
+          ./boot
+          ./configure $CONFIGURE_ARGS
+
+      - name: build-ghc
+        working-directory: ${{ runner.temp }}/ghc
+        run: |
+          hadrian/build --no-color --no-progress --no-time --flavour=perf --hash-unit-ids --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-{haddock,hpc,runghc}
+
+      - name: build-bindist
+        working-directory: ${{ runner.temp }}/ghc
+        run: |
+          BINDIST_NAME=$(basename _build/bindist/*)
+          gtar --sort=name --mtime="@$(git log -1 --pretty=%ct)" --owner=0 --group=0 --numeric-owner --use-compress-program="zstd --ultra -22 --threads=0" -cf _build/bindist/$BINDIST_NAME.tar.zst -C _build/bindist $BINDIST_NAME
+
+      - name: upload-bindist
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghc-wasm-aarch64-linux-bindist
+          path: ${{ runner.temp }}/ghc/_build/bindist/*.tar.zst
+
+      - name: test-ghc
+        working-directory: ${{ runner.temp }}/ghc
+        run: |
+          hadrian/build --no-color --no-progress --no-time --flavour=perf --hash-unit-ids --docs=none -j test

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -296,6 +296,18 @@ bindistInfos =
                 }
           },
       (,)
+        "wasm32-wasi-ghc-gmp-aarch64-linux"
+        BindistInfo
+          { isGhcBindist = False,
+            src =
+              GitHubArtifact
+                { ownerRepo = "tweag/ghc-wasm-bindists",
+                  branch = "main",
+                  workflowName = "ghc-wasm-aarch64-linux-bindist",
+                  artifactName = "ghc-wasm-aarch64-linux-bindist"
+                }
+          },
+      (,)
         "wasi-sdk"
         BindistInfo
           { isGhcBindist = False,


### PR DESCRIPTION
Related: #15. The custom runner `makima` is a ubi8 container on my personal server.

It's a pity github runner doesn't officially support alpine yet (see https://github.com/actions/runner/issues/801). I'm not interested in the workarounds out there, so might as well build our aarch64-linux bindists in a distro with reasonably old glibc and will still be actively supported for a while.