### PR TITLE
Support single entry `.zip`s, support `.zstd` bindists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,9 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build
         run: nix build -L
+      - name: Run from scratch
+        id: run-from-scratch
+        run: |
+          rm meta.json
+          nix run . -- --download-url-prefix https://example.org/
+          cat meta.json

--- a/ghc-wasm-bindists.cabal
+++ b/ghc-wasm-bindists.cabal
@@ -10,6 +10,7 @@ executable ghc-wasm-bindists
     , base
     , base64
     , conduit
+    , conduit-zstd
     , containers
     , cryptohash-sha256
     , deriving-aeson
@@ -23,8 +24,9 @@ executable ghc-wasm-bindists
     , relude
     , tar-conduit
     , unliftio
+    , zip-stream
   mixins: base hiding (Prelude), relude (Relude as Prelude), relude
   hs-source-dirs: app
   default-language: GHC2021
-  default-extensions: ApplicativeDo BlockArguments DataKinds DeriveAnyClass DeriveGeneric DerivingStrategies DerivingVia DuplicateRecordFields LambdaCase NoFieldSelectors OverloadedLabels OverloadedRecordDot OverloadedStrings RecordWildCards StrictData
+  default-extensions: ApplicativeDo BlockArguments DataKinds DeriveAnyClass DeriveGeneric DerivingStrategies DerivingVia DuplicateRecordFields LambdaCase NoFieldSelectors OverloadedLabels OverloadedRecordDot OverloadedStrings RecordWildCards StrictData ViewPatterns
   ghc-options: -Wall -Werror -Wunused-packages -Wwarn=unused-packages -Wno-name-shadowing


### PR DESCRIPTION
See https://github.com/tweag/ghc-wasm-bindists/pull/18#discussion_r1606837897

This results eg in
```json
    "wasm32-wasi-ghc-gmp-x86_64-darwin": {
        "ghcSubdir": "ghc-9.11.20240519-wasm32-wasi",
        "mirrorUrl": "https://example.org/wasm32-wasi-ghc-gmp-x86_64-darwin.tar.zst",
        "originalUrl": "https://nightly.link/tweag/ghc-wasm-bindists/actions/artifacts/1517260460.zip",
        "sriHash": "sha256-jPlDE353GtKm0xFVknuslplZdCEqMcwLMcHk2GzOr6M="
    },
```