### PR TITLE
Fix aarch64-linux build & wasi-sdk artifact info

### DIFF
--- a/.github/workflows/aarch64-linux-bindist.yml
+++ b/.github/workflows/aarch64-linux-bindist.yml
@@ -11,59 +11,29 @@ on:
 jobs:
   ghc-wasm-aarch64-linux-bindist:
     name: ghc-wasm-aarch64-linux-bindist
-    runs-on: makima
+    runs-on:
+      - self-hosted
+      - Linux
+      - ARM64
     steps:
 
-      - name: update-system-deps
-        run: |
-          sudo dnf upgrade -y
+      - name: checkout
+        uses: actions/checkout@v4
 
-      - name: setup-haskell
-        uses: haskell-actions/setup@v2
-
-      - name: setup-cabal-deps
+      - name: build & test
         run: |
-          cabal install \
-            --overwrite-policy=always \
-            alex \
-            happy
-
-      - name: setup-ghc-wasm-meta
-        run: |
-          curl https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=${{ runner.temp }}/.ghc-wasm SKIP_GHC=1 sh
-          ${{ runner.temp }}/.ghc-wasm/add_to_github_path.sh
-
-      - name: build-hadrian
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth=1 --recurse-submodules --shallow-submodules --jobs 32 https://gitlab.haskell.org/ghc/ghc.git
-          cd ghc
-          ./hadrian/build --version
-
-      - name: configure-ghc
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          ./boot
-          ./configure $CONFIGURE_ARGS
-
-      - name: build-ghc
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          hadrian/build --no-color --no-progress --no-time --flavour=perf+text_simdutf --hash-unit-ids --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-{haddock,hpc,runghc}
-
-      - name: build-bindist
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          BINDIST_NAME=$(basename _build/bindist/*)
-          gtar --sort=name --mtime="@$(git log -1 --pretty=%ct)" --owner=0 --group=0 --numeric-owner --use-compress-program="zstd --ultra -22 --threads=0" -cf _build/bindist/$BINDIST_NAME.tar.zst -C _build/bindist $BINDIST_NAME
+          podman run \
+            --rm \
+            --init \
+            --network host \
+            --pull always \
+            --volume $PWD:/workspace \
+            --workdir /workspace \
+            alpine \
+            /workspace/alpine-build.sh
 
       - name: upload-bindist
         uses: actions/upload-artifact@v4
         with:
           name: ghc-wasm-aarch64-linux-bindist
-          path: ${{ runner.temp }}/ghc/_build/bindist/*.tar.zst
-
-      - name: test-ghc
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          hadrian/build --no-color --no-progress --no-time --flavour=perf+text_simdutf --hash-unit-ids --docs=none -j test
+          path: ghc-*.tar.zst

--- a/alpine-build.sh
+++ b/alpine-build.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -eu
+
+export PATH=~/.local/bin:"$PATH"
+
+apk upgrade
+apk add \
+  alpine-sdk \
+  autoconf \
+  automake \
+  bash \
+  cabal \
+  coreutils \
+  ghc \
+  jq \
+  nodejs \
+  python3 \
+  xz \
+  zstd
+
+cd "$(mktemp -d)"
+curl -f -L --retry 5 https://github.com/tweag/rust-alpine-mimalloc/archive/refs/heads/master.tar.gz | tar xz --strip-components=1
+mv mimalloc.diff /tmp
+./build.sh
+cd "$OLDPWD"
+
+export LD_PRELOAD=/usr/lib/libmimalloc.so
+
+cd "$(mktemp -d)"
+curl -f -L --retry 5 https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=$PWD SKIP_GHC=1 sh
+ln -sf /usr/bin/node "$PWD/nodejs/bin/node"
+. "$PWD/env"
+cd "$OLDPWD"
+
+cd "$(mktemp -d)"
+
+git clone --depth=1 --recurse-submodules --shallow-submodules --jobs 32 https://gitlab.haskell.org/ghc/ghc.git .
+
+cabal update
+
+./hadrian/build --version
+
+cabal install \
+  alex \
+  happy
+
+./boot
+
+./configure --host="$(uname -m)-alpine-linux" --target=wasm32-wasi --with-intree-gmp --with-system-libffi
+
+hadrian/build --no-color --no-progress --no-time --flavour=perf+fully_static+text_simdutf --hash-unit-ids --docs=none -j binary-dist-dir test:all_deps
+
+BINDIST_NAME=$(basename _build/bindist/*)
+
+tar --sort=name --mtime="@$(git log -1 --pretty=%ct)" --owner=0 --group=0 --numeric-owner --use-compress-program="zstd --ultra -22 --threads=0" -cf /workspace/$BINDIST_NAME.tar.zst -C _build/bindist $BINDIST_NAME
+
+hadrian/build --no-color --no-progress --no-time --flavour=perf+fully_static+text_simdutf --hash-unit-ids --docs=none -j test
+
+cd "$OLDPWD"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -377,12 +377,12 @@ bindistInfos =
                   projectId = 3212,
                   ref = "master",
                   jobName = "x86_64-linux",
-                  artifactPath = "dist/wasi-sdk-22-linux.tar.gz",
+                  artifactPath = "dist/wasi-sdk-25.0-x86_64-linux.tar.gz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },
       (,)
-        "wasi-sdk-darwin"
+        "wasi-sdk-aarch64-darwin"
         BindistInfo
           { dlArgs = rawFileDownloadArgs,
             src =
@@ -390,8 +390,22 @@ bindistInfos =
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 3212,
                   ref = "master",
-                  jobName = "darwin",
-                  artifactPath = "dist/wasi-sdk-22-macos.tar.gz",
+                  jobName = "aarch64-darwin",
+                  artifactPath = "dist/wasi-sdk-25.0-arm64-macos.tar.gz",
+                  pipelineFilter = [("status", Just "success")]
+                }
+          },
+      (,)
+        "wasi-sdk-x86_64-darwin"
+        BindistInfo
+          { dlArgs = rawFileDownloadArgs,
+            src =
+              GitLabArtifact
+                { gitlabDomain = "gitlab.haskell.org",
+                  projectId = 3212,
+                  ref = "master",
+                  jobName = "x86_64-darwin",
+                  artifactPath = "dist/wasi-sdk-25.0-arm64-macos.tar.gz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },
@@ -405,7 +419,7 @@ bindistInfos =
                   projectId = 3212,
                   ref = "master",
                   jobName = "aarch64-linux",
-                  artifactPath = "dist/wasi-sdk-22-linux.tar.gz",
+                  artifactPath = "dist/wasi-sdk-25.0-aarch64-linux.tar.gz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },


### PR DESCRIPTION
- The previous `aarch64-linux` runner `makima` has been dismantled. I've set up a new `aarch64-linux` nixos runner that can run `podman`. Now we can build static ghc bindists for aarch64-linux as well in an alpine container.
- Update wasi-sdk artifact info. Our wasi-sdk fork now uses upstream cmake build rules, and aarch64/x86-64 darwin artifacts are now separate.