### PR TITLE
Correct wasi-sdk metadata again, sigh

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -391,7 +391,7 @@ bindistInfos =
                   projectId = 3212,
                   ref = "master",
                   jobName = "aarch64-darwin",
-                  artifactPath = "dist/wasi-sdk-25.0-arm64-macos.tar.gz",
+                  artifactPath = "dist/wasi-sdk-25.0-x86_64-macos.tar.gz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },
@@ -405,7 +405,7 @@ bindistInfos =
                   projectId = 3212,
                   ref = "master",
                   jobName = "x86_64-darwin",
-                  artifactPath = "dist/wasi-sdk-25.0-arm64-macos.tar.gz",
+                  artifactPath = "dist/wasi-sdk-25.0-x86_64-macos.tar.gz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },


### PR DESCRIPTION
Why is aarch64-darwin artifact named `dist/wasi-sdk-25.0-x86_64-macos.tar.gz` when it's built on an aarch64-darwin host??? I have no idea, the other way was explainable due to rosetta emulation but I don't know what's going on with the build. But the tarballs seem to work on my macbook, the binary archs are correct so ¯\_(ツ)_/¯