### PR TITLE
Fix bindist build scripts

### DIFF
--- a/.github/workflows/darwin-bindist.yml
+++ b/.github/workflows/darwin-bindist.yml
@@ -61,7 +61,7 @@ jobs:
       - name: build-ghc
         working-directory: ${{ runner.temp }}/ghc
         run: |
-          hadrian/build --no-color --no-progress --no-time --flavour=release+text_simdutf --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-{haddock,hpc,runghc}
+          hadrian/build --no-color --no-progress --no-time --flavour=perf+text_simdutf --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-{haddock,hpc,runghc}
 
       - name: build-bindist
         working-directory: ${{ runner.temp }}/ghc
@@ -78,4 +78,4 @@ jobs:
       - name: test-ghc
         working-directory: ${{ runner.temp }}/ghc
         run: |
-          hadrian/build --no-color --no-progress --no-time --flavour=release+text_simdutf --docs=none -j test
+          hadrian/build --no-color --no-progress --no-time --flavour=perf+text_simdutf --docs=none -j test

--- a/.github/workflows/darwin-bindist.yml
+++ b/.github/workflows/darwin-bindist.yml
@@ -37,8 +37,8 @@ jobs:
       - name: setup-cabal-deps
         run: |
           cabal install \
-            alex \
-            happy
+            alex-3.5.1.0 \
+            happy-2.0.2
 
       - name: setup-ghc-wasm-meta
         run: |

--- a/alpine-build.sh
+++ b/alpine-build.sh
@@ -48,12 +48,12 @@ cabal install \
 
 ./configure --host="$(uname -m)-alpine-linux" --target=wasm32-wasi --with-intree-gmp --with-system-libffi
 
-hadrian/build --no-color --no-progress --no-time --flavour=release+host_fully_static+text_simdutf --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-haddock _build/stage0/bin/wasm32-wasi-hpc _build/stage0/bin/wasm32-wasi-runghc
+hadrian/build --no-color --no-progress --no-time --flavour=perf+host_fully_static+text_simdutf --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-haddock _build/stage0/bin/wasm32-wasi-hpc _build/stage0/bin/wasm32-wasi-runghc
 
 BINDIST_NAME=$(basename _build/bindist/*)
 
 tar --sort=name --mtime="@$(git log -1 --pretty=%ct)" --owner=0 --group=0 --numeric-owner --use-compress-program="zstd --ultra -22 --threads=0" -cf /workspace/$BINDIST_NAME.tar.zst -C _build/bindist $BINDIST_NAME
 
-hadrian/build --no-color --no-progress --no-time --flavour=release+host_fully_static+text_simdutf --docs=none -j test
+hadrian/build --no-color --no-progress --no-time --flavour=perf+host_fully_static+text_simdutf --docs=none -j test
 
 cd "$OLDPWD"

--- a/alpine-build.sh
+++ b/alpine-build.sh
@@ -41,8 +41,8 @@ cabal update
 ./hadrian/build --version
 
 cabal install \
-  alex \
-  happy
+  alex-3.5.1.0 \
+  happy-2.0.2
 
 ./boot
 


### PR DESCRIPTION
- Just stick to fixed `alex`/`happy` versions, otherwise another `happy` release may break configure version check
- We can use `perf` instead of `release` again since !13476 landed