### PR TITLE
Use recent cabal artifacts from 3.14 branch

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -473,9 +473,9 @@ bindistInfos =
               GitLabArtifact
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1164,
-                  ref = "cabal-head",
+                  ref = "Cabal-syntax-3.14.0.0",
                   jobName = "alpine-linux: [x86_64, alpine3_18, x86_64-linux]",
-                  artifactPath = "out/cabal-install-3.15.0.0-x86_64-linux-alpine3_18.tar.xz",
+                  artifactPath = "out/cabal-install-3.14.0.0-x86_64-linux-alpine3_18.tar.xz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },
@@ -487,9 +487,9 @@ bindistInfos =
               GitLabArtifact
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1164,
-                  ref = "cabal-head",
+                  ref = "Cabal-syntax-3.14.0.0",
                   jobName = "alpine-linux: [aarch64, alpine3_18, aarch64-linux]",
-                  artifactPath = "out/cabal-install-3.15.0.0-aarch64-linux-alpine3_18.tar.xz",
+                  artifactPath = "out/cabal-install-3.14.0.0-aarch64-linux-alpine3_18.tar.xz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },
@@ -501,9 +501,9 @@ bindistInfos =
               GitLabArtifact
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1164,
-                  ref = "cabal-head",
+                  ref = "Cabal-syntax-3.14.0.0",
                   jobName = "darwin: [aarch64, arm64]",
-                  artifactPath = "out/cabal-install-3.15.0.0-aarch64-darwin.tar.xz",
+                  artifactPath = "out/cabal-install-3.14.0.0-aarch64-darwin.tar.xz",
                   pipelineFilter = [("status", Just "success")]
                 }
           },
@@ -515,9 +515,9 @@ bindistInfos =
               GitLabArtifact
                 { gitlabDomain = "gitlab.haskell.org",
                   projectId = 1164,
-                  ref = "cabal-head",
+                  ref = "Cabal-syntax-3.14.0.0",
                   jobName = "darwin: [x86_64, x86_64]",
-                  artifactPath = "out/cabal-install-3.15.0.0-x86_64-darwin.tar.xz",
+                  artifactPath = "out/cabal-install-3.14.0.0-x86_64-darwin.tar.xz",
                   pipelineFilter = [("status", Just "success")]
                 }
           }


### PR DESCRIPTION
I've manually checked that they work for wasm TH/ghci, and we should prefer release branches of cabal.