### PR TITLE
ci: use makima for ci jobs

### DIFF
--- a/.github/actions/darwin-bindist/action.yml
+++ b/.github/actions/darwin-bindist/action.yml
@@ -1,0 +1,65 @@
+name: ghc-wasm-darwin-bindist
+runs:
+  using: composite
+  steps:
+    - name: setup-brew-deps
+      shell: bash
+      run: |
+        brew install automake || true
+
+    - name: setup-haskell
+      uses: haskell-actions/setup@v2
+
+    - name: build-hadrian
+      working-directory: ${{ runner.temp }}
+      shell: bash
+      run: |
+        git clone --branch=${{ matrix.branch }} --depth=1 --recurse-submodules --shallow-submodules --jobs 32 ${{ matrix.remote }}
+        cd ghc
+        ./hadrian/build --version
+
+    - name: setup-cabal-deps
+      shell: bash
+      run: |
+        cabal install \
+          --overwrite-policy=always \
+          alex-3.5.1.0 \
+          happy-1.20.1.1
+
+    - name: setup-ghc-wasm-meta
+      shell: bash
+      run: |
+        curl https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=${{ runner.temp }}/.ghc-wasm SKIP_GHC=1 sh
+        ${{ runner.temp }}/.ghc-wasm/add_to_github_path.sh
+
+    - name: configure-ghc
+      working-directory: ${{ runner.temp }}/ghc
+      shell: bash
+      run: |
+        ./boot
+        ./configure $CONFIGURE_ARGS
+
+    - name: build-ghc
+      working-directory: ${{ runner.temp }}/ghc
+      shell: bash
+      run: |
+        hadrian/build --no-color --no-progress --no-time --flavour=${{ matrix.flavour }} --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-{haddock,hpc,runghc}
+
+    - name: build-bindist
+      working-directory: ${{ runner.temp }}/ghc
+      shell: bash
+      run: |
+        BINDIST_NAME=$(basename _build/bindist/*)
+        tar --use-compress-program="zstd --ultra -22 --threads=0" -cf _build/bindist/$BINDIST_NAME.tar.zst -C _build/bindist $BINDIST_NAME
+
+    - name: upload-bindist
+      uses: actions/upload-artifact@v4
+      with:
+        name: ghc-wasm-${{ matrix.arch }}-darwin-${{ matrix.branch }}-bindist
+        path: ${{ runner.temp }}/ghc/_build/bindist/*.tar.zst
+
+    - name: test-ghc
+      working-directory: ${{ runner.temp }}/ghc
+      shell: bash
+      run: |
+        hadrian/build --no-color --no-progress --no-time --flavour=${{ matrix.flavour }} --docs=none -j test

--- a/.github/workflows/aarch64-linux-bindist.yml
+++ b/.github/workflows/aarch64-linux-bindist.yml
@@ -12,10 +12,7 @@ on:
 jobs:
   ghc-wasm-aarch64-linux-bindist:
     name: ghc-wasm-aarch64-linux-bindist
-    runs-on:
-      - self-hosted
-      - Linux
-      - ARM64
+    runs-on: makima
     steps:
 
       - name: checkout
@@ -23,7 +20,7 @@ jobs:
 
       - name: build & test
         run: |
-          podman run \
+          docker run \
             --rm \
             --init \
             --network host \

--- a/.github/workflows/darwin-bindist.yml
+++ b/.github/workflows/darwin-bindist.yml
@@ -9,73 +9,50 @@ on:
     - cron: '0 6 * * 0'
 
 jobs:
-  ghc-wasm-darwin-bindist:
-    name: ghc-wasm-${{ matrix.arch }}-darwin-bindist
-    runs-on: ${{ matrix.os }}
+  ghc-wasm-aarch64-darwin-bindist:
+    name: ghc-wasm-aarch64-darwin-${{ matrix.branch }}-bindist
+    runs-on: makima
     strategy:
       matrix:
         include:
           - arch: aarch64
-            os: macos-15
-          - arch: x86_64
-            os: macos-15-large
+            branch: master
+            remote: https://gitlab.haskell.org/ghc/ghc.git
+            flavour: release+text_simdutf
+          - arch: aarch64
+            branch: ghc-9.12
+            remote: https://gitlab.haskell.org/TerrorJack/ghc.git
+            flavour: release+text_simdutf
+          - arch: aarch64
+            branch: ghc-9.10
+            remote: https://gitlab.haskell.org/TerrorJack/ghc.git
+            flavour: release
     env:
       MACOSX_DEPLOYMENT_TARGET: "13.0"
     steps:
 
-      - name: setup-xcode
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_16.1.app
+      - name: checkout
+        uses: actions/checkout@v4
 
-      - name: setup-brew-deps
-        run: |
-          brew install automake
+      - name: ghc-wasm-darwin-bindist
+        uses: ./.github/actions/darwin-bindist
 
-      - name: setup-haskell
-        uses: haskell-actions/setup@v2
+  ghc-wasm-x86_64-darwin-bindist:
+    name: ghc-wasm-x86_64-darwin-${{ matrix.branch }}-bindist
+    runs-on: macos-15-large
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            branch: master
+            remote: https://gitlab.haskell.org/ghc/ghc.git
+            flavour: release+text_simdutf
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "13.0"
+    steps:
 
-      - name: setup-cabal-deps
-        run: |
-          cabal install \
-            alex-3.5.1.0 \
-            happy-2.0.2
+      - name: checkout
+        uses: actions/checkout@v4
 
-      - name: setup-ghc-wasm-meta
-        run: |
-          curl https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=${{ runner.temp }}/.ghc-wasm SKIP_GHC=1 sh
-          ${{ runner.temp }}/.ghc-wasm/add_to_github_path.sh
-
-      - name: build-hadrian
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --ref-format=reftable --depth=1 --recurse-submodules --shallow-submodules --jobs 32 https://gitlab.haskell.org/ghc/ghc.git
-          cd ghc
-          ./hadrian/build --version
-
-      - name: configure-ghc
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          ./boot
-          ./configure $CONFIGURE_ARGS
-
-      - name: build-ghc
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          hadrian/build --no-color --no-progress --no-time --flavour=release+text_simdutf --docs=none -j binary-dist-dir test:all_deps _build/stage0/bin/wasm32-wasi-{haddock,hpc,runghc}
-
-      - name: build-bindist
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          BINDIST_NAME=$(basename _build/bindist/*)
-          gtar --sort=name --mtime="@$(git log -1 --pretty=%ct)" --owner=0 --group=0 --numeric-owner --use-compress-program="zstd --ultra -22 --threads=0" -cf _build/bindist/$BINDIST_NAME.tar.zst -C _build/bindist $BINDIST_NAME
-
-      - name: upload-bindist
-        uses: actions/upload-artifact@v4
-        with:
-          name: ghc-wasm-${{ matrix.arch }}-darwin-bindist
-          path: ${{ runner.temp }}/ghc/_build/bindist/*.tar.zst
-
-      - name: test-ghc
-        working-directory: ${{ runner.temp }}/ghc
-        run: |
-          hadrian/build --no-color --no-progress --no-time --flavour=release+text_simdutf --docs=none -j test
+      - name: ghc-wasm-darwin-bindist
+        uses: ./.github/actions/darwin-bindist

--- a/alpine-build.sh
+++ b/alpine-build.sh
@@ -14,6 +14,7 @@ apk add \
   coreutils \
   ghc \
   jq \
+  musl-locales \
   ncurses-static \
   python3 \
   xz \
@@ -42,7 +43,7 @@ cabal update
 
 cabal install \
   alex-3.5.1.0 \
-  happy-2.0.2
+  happy-1.20.1.1
 
 ./boot
 


### PR DESCRIPTION
Retire `aarch64-linux` runner `elysee`, use `aarch64-darwin` runner `makima`. Add 9.12/9.10 bindists for `aarch64-darwin` as well.