### PR TITLE
ci: migrate to haskell-wasm runners to build ghc bindists

### DIFF
--- a/.github/actions/darwin-bindist/action.yml
+++ b/.github/actions/darwin-bindist/action.yml
@@ -2,10 +2,6 @@ name: ghc-wasm-darwin-bindist
 runs:
   using: composite
   steps:
-    - name: setup-brew-deps
-      shell: bash
-      run: |
-        brew install automake || true
 
     - name: setup-haskell
       uses: haskell-actions/setup@v2

--- a/.github/workflows/aarch64-linux-bindist.yml
+++ b/.github/workflows/aarch64-linux-bindist.yml
@@ -12,7 +12,10 @@ on:
 jobs:
   ghc-wasm-aarch64-linux-bindist:
     name: ghc-wasm-aarch64-linux-bindist
-    runs-on: makima
+    runs-on:
+      - ARM64
+      - Linux
+      - podman
     steps:
 
       - name: checkout
@@ -20,7 +23,7 @@ jobs:
 
       - name: build & test
         run: |
-          docker run \
+          podman run \
             --rm \
             --init \
             --network host \

--- a/.github/workflows/darwin-bindist.yml
+++ b/.github/workflows/darwin-bindist.yml
@@ -12,8 +12,11 @@ on:
 jobs:
   ghc-wasm-aarch64-darwin-bindist:
     name: ghc-wasm-aarch64-darwin-${{ matrix.branch }}-bindist
-    runs-on: makima
+    runs-on:
+      - ARM64
+      - macOS
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -39,8 +42,11 @@ jobs:
         uses: ./.github/actions/darwin-bindist
 
   ghc-wasm-x86_64-darwin-bindist:
+    needs: ghc-wasm-aarch64-darwin-bindist
     name: ghc-wasm-x86_64-darwin-${{ matrix.branch }}-bindist
-    runs-on: macos-15-large
+    runs-on:
+      - X64
+      - macOS
     strategy:
       matrix:
         include:

--- a/alpine-build.sh
+++ b/alpine-build.sh
@@ -10,11 +10,12 @@ apk add \
   autoconf \
   automake \
   bash \
-  cabal \
   coreutils \
-  ghc \
+  curl \
+  gmp-dev \
   jq \
   musl-locales \
+  ncurses-dev \
   ncurses-static \
   python3 \
   xz \
@@ -29,9 +30,11 @@ cd "$OLDPWD"
 export LD_PRELOAD=/usr/lib/libmimalloc.so
 
 cd "$(mktemp -d)"
-curl -f -L --retry 5 https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=$PWD SKIP_GHC=1 sh
-. "$PWD/env"
-cd "$OLDPWD"
+curl -f -L --retry 5 https://downloads.haskell.org/ghc/9.10.1/ghc-9.10.1-aarch64-alpine3_18-linux.tar.xz | tar xJ --strip-components=1
+./configure --prefix=$HOME/.local
+make install -j16
+
+curl -f -L --retry 5 https://downloads.haskell.org/cabal/cabal-install-3.12.1.0/cabal-install-3.12.1.0-aarch64-linux-alpine3_18.tar.xz | tar xJ -C ~/.local/bin cabal
 
 cd "$(mktemp -d)"
 
@@ -46,6 +49,11 @@ cabal install \
   happy-1.20.1.1
 
 ./boot
+
+cd "$(mktemp -d)"
+curl -f -L --retry 5 https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | PREFIX=$PWD SKIP_GHC=1 sh
+. "$PWD/env"
+cd "$OLDPWD"
 
 ./configure --host="$(uname -m)-alpine-linux" --target=wasm32-wasi --with-intree-gmp --with-system-libffi
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -351,7 +351,7 @@ bindistInfos =
           { dlArgs = DownloadArgs {isSingleEntryZip = True, isGhcBindist = Just Zstd},
             src =
               GitHubArtifact
-                { ownerRepo = "tweag/ghc-wasm-bindists",
+                { ownerRepo = "haskell-wasm/ghc-wasm-bindists",
                   branch = "main",
                   workflowName = "ghc-wasm-darwin-bindist",
                   artifactName = "ghc-wasm-aarch64-darwin-master-bindist"
@@ -363,7 +363,7 @@ bindistInfos =
           { dlArgs = DownloadArgs {isSingleEntryZip = True, isGhcBindist = Just Zstd},
             src =
               GitHubArtifact
-                { ownerRepo = "tweag/ghc-wasm-bindists",
+                { ownerRepo = "haskell-wasm/ghc-wasm-bindists",
                   branch = "main",
                   workflowName = "ghc-wasm-darwin-bindist",
                   artifactName = "ghc-wasm-aarch64-darwin-ghc-9.12-bindist"
@@ -375,7 +375,7 @@ bindistInfos =
           { dlArgs = DownloadArgs {isSingleEntryZip = True, isGhcBindist = Just Zstd},
             src =
               GitHubArtifact
-                { ownerRepo = "tweag/ghc-wasm-bindists",
+                { ownerRepo = "haskell-wasm/ghc-wasm-bindists",
                   branch = "main",
                   workflowName = "ghc-wasm-darwin-bindist",
                   artifactName = "ghc-wasm-aarch64-darwin-ghc-9.10-bindist"
@@ -387,7 +387,7 @@ bindistInfos =
           { dlArgs = DownloadArgs {isSingleEntryZip = True, isGhcBindist = Just Zstd},
             src =
               GitHubArtifact
-                { ownerRepo = "tweag/ghc-wasm-bindists",
+                { ownerRepo = "haskell-wasm/ghc-wasm-bindists",
                   branch = "main",
                   workflowName = "ghc-wasm-darwin-bindist",
                   artifactName = "ghc-wasm-x86_64-darwin-master-bindist"
@@ -399,7 +399,7 @@ bindistInfos =
           { dlArgs = DownloadArgs {isSingleEntryZip = True, isGhcBindist = Just Zstd},
             src =
               GitHubArtifact
-                { ownerRepo = "tweag/ghc-wasm-bindists",
+                { ownerRepo = "haskell-wasm/ghc-wasm-bindists",
                   branch = "main",
                   workflowName = "ghc-wasm-aarch64-linux-bindist",
                   artifactName = "ghc-wasm-aarch64-linux-bindist"


### PR DESCRIPTION
`makima` has been migrated to `haskell-wasm` org and now only used for `aarch64-darwin` bindists now, we have a standalone `aarch64-linux` runner `roxy`. instead of designating runners directly by name, we designate platform and capability, so if we add more runners in the future it can scale up automatically.