### PR TITLE
Use self hosted runners for everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,14 @@ on:
       - synchronize
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - X64
+      - Linux
+      - ubuntu
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Build
         run: nix build -L
       - name: Run from scratch

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,13 +10,16 @@ on:
     - cron: '0 20 * * 0'
 jobs:
   mirror:
-    runs-on: ubuntu-latest
+    runs-on:
+      - X64
+      - Linux
+      - ubuntu
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Set release tag name
         id: release-tag-name
         run: |


### PR DESCRIPTION
The `ubuntu`-tagged runners are based on `ubuntu:runner-24.04` of https://github.com/catthehacker/docker_images, which should mimic experience of github hosted runners to a large extent. Let's see if it works for us..