### PR TITLE
Remove magic-nix-cache-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Build
         run: nix build -L
       - name: Run from scratch

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Set release tag name
         id: release-tag-name
         run: |


### PR DESCRIPTION
https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

Shouldn't matter too much given that e.g. the Haskell deps are cached on cache.nixos.org